### PR TITLE
Vagrant based environment and interactive DHCP test

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+$startovs = <<SCRIPT
+    sudo /usr/local/share/openvswitch/scripts/ovs-ctl --system-id=random start
+    sudo ovs-vsctl --version
+SCRIPT
+
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "floodlight/mininet"
+  config.vm.box_version = "0.0.1"
+
+  config.vm.hostname = "floodlight"
+  config.vm.network :private_network, type: "dhcp"
+
+  config.vm.synced_folder "example/", "/home/vagrant/example/"
+
+  config.vm.provision "shell", inline: $startovs
+end

--- a/example/mininet/dhcp.py
+++ b/example/mininet/dhcp.py
@@ -47,7 +47,6 @@ def rest_call(path, data, action):
     conn.close()
     return ret
 
-
 def addDHCPInstance(name):
     data = {
         "name"         : name,
@@ -70,7 +69,7 @@ def addDHCPInstance(name):
 
 def addNodePortTupleToDHCPInstance(name):
     data = {
-        "switchport": [
+        "switchports": [
             {
                 "dpid": "1",
                 "port": "1"
@@ -80,6 +79,12 @@ def addNodePortTupleToDHCPInstance(name):
     ret = rest_call('/wm/dhcp/instance/' + name, data, 'POST')
     return ret
 
+def enableDHCPServer():
+    data = {
+        "enable" : "true"
+    }
+    ret = rest_call('/wm/dhcp/config', data, 'POST')
+    return ret
 
 # DHCP client functions
 
@@ -105,7 +110,7 @@ def waitForIP(host):
         time.sleep(1)
     info('\n')
     info('*', host, 'is now using',
-         host.cmd('grep nameserver /etc/resolv.conf'))
+         host.cmd('grep nameserver /etcresolv.conf'))
 
 
 def mountPrivateResolvconf(host):
@@ -142,6 +147,9 @@ def startNetwork():
     net.start()
 
     # Start DHCP
+    ret = enableDHCPServer()
+    print(ret)
+
     ret = addDHCPInstance('mininet-dhcp')
     print(ret)
 

--- a/example/mininet/dhcp.py
+++ b/example/mininet/dhcp.py
@@ -1,0 +1,227 @@
+#!/usr/bin/python
+import json
+
+import httplib
+import os
+import subprocess
+import time
+from mininet.cli import CLI
+from mininet.log import setLogLevel, info
+from mininet.net import Mininet
+from mininet.node import RemoteController
+from mininet.topo import Topo
+
+HOME_FOLDER = os.getenv('HOME')
+
+
+class DHCPTopo(Topo):
+    def __init__(self, *args, **kwargs):
+        Topo.__init__(self, *args, **kwargs)
+        h1 = self.addHost('h1', ip='10.0.0.10/24')
+        h2 = self.addHost('h2', ip='10.0.0.20/24')
+        switch = self.addSwitch('s1')
+        self.addLink(h1, switch)
+        self.addLink(h2, switch)
+
+
+def getControllerIP():
+    guest_ip = subprocess.check_output("/sbin/ifconfig eth1 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'",
+                                       shell=True)
+    split_ip = guest_ip.split('.')
+    split_ip[3] = '1'
+    return '.'.join(split_ip)
+
+
+def rest_call(path, data, action):
+    headers = {
+        'Content-type': 'application/json',
+        'Accept'      : 'application/json',
+    }
+    body = json.dumps(data)
+
+    conn = httplib.HTTPConnection(getControllerIP(), 8080)
+    conn.request(action, path, body, headers)
+    response = conn.getresponse()
+
+    ret = (response.status, response.reason, response.read())
+    conn.close()
+    return ret
+
+
+def addDHCPInstance(name):
+    data = {
+        "name"         : name,
+        "start-ip"     : "10.0.0.100",
+        "end-ip"       : "10.0.0.200",
+        "server-id"    : "10.0.0.2",
+        "server-mac"   : "aa:bb:cc:dd:ee:ff",
+        "router-ip"    : "10.0.0.1",
+        "broadcast-ip" : "10.0.0.255",
+        "subnet-mask"  : "255.255.255.0",
+        "lease-time"   : "60",
+        "rebind-time"  : "60",
+        "renew-time"   : "60",
+        "ip-forwarding": "true",
+        "domain-name"  : "mininet-domain-name"
+    }
+    ret = rest_call('/wm/dhcp/instance', data, 'POST')
+    return ret
+
+
+def addNodePortTupleToDHCPInstance(name):
+    data = {
+        "switchport": [
+            {
+                "dpid": "1",
+                "port": "1"
+            }
+        ]
+    }
+    ret = rest_call('/wm/dhcp/instance/' + name, data, 'POST')
+    return ret
+
+
+# DHCP client functions
+
+def startDHCPclient(host):
+    "Start DHCP client on host"
+    intf = host.defaultIntf()
+    host.cmd('dhclient -v -d -r', intf)
+    host.cmd('dhclient -v -d 1> /tmp/dhclient.log 2>&1', intf, '&')
+
+
+def stopDHCPclient(host):
+    host.cmd('kill %dhclient')
+
+
+def waitForIP(host):
+    "Wait for an IP address"
+    info('*', host, 'waiting for IP address')
+    while True:
+        host.defaultIntf().updateIP()
+        if host.IP():
+            break
+        info('.')
+        time.sleep(1)
+    info('\n')
+    info('*', host, 'is now using',
+         host.cmd('grep nameserver /etc/resolv.conf'))
+
+
+def mountPrivateResolvconf(host):
+    "Create/mount private /etc/resolv.conf for host"
+    etc = '/tmp/etc-%s' % host
+    host.cmd('mkdir -p', etc)
+    host.cmd('mount --bind /etc', etc)
+    host.cmd('mount -n -t tmpfs tmpfs /etc')
+    host.cmd('ln -s %s/* /etc/' % etc)
+    host.cmd('rm /etc/resolv.conf')
+    host.cmd('cp %s/resolv.conf /etc/' % etc)
+
+
+def unmountPrivateResolvconf(host):
+    "Unmount private /etc dir for host"
+    etc = '/tmp/etc-%s' % host
+    host.cmd('umount /etc')
+    host.cmd('umount', etc)
+    host.cmd('rmdir', etc)
+
+
+def startNetwork():
+    # Create the network from a given topology without building it yet
+    global net
+    net = Mininet(topo=DHCPTopo(), build=False)
+
+    remote_ip = getControllerIP()
+    info('** Adding Floodlight Controller\n')
+    net.addController('c1', controller=RemoteController,
+                      ip=remote_ip, port=6653)
+
+    # Build the network
+    net.build()
+    net.start()
+
+    # Start DHCP
+    ret = addDHCPInstance('mininet-dhcp')
+    print(ret)
+
+    ret = addNodePortTupleToDHCPInstance('mininet-dhcp')
+    print(ret)
+
+    h1 = net.get('h1')
+    mountPrivateResolvconf(h1)
+    startDHCPclient(h1)
+    waitForIP(h1)
+
+
+def stopNetwork():
+    if net is not None:
+        info('** Tearing down network\n')
+        h1 = net.get('h1')
+        unmountPrivateResolvconf(h1)
+        stopDHCPclient(h1)
+        net.stop()
+
+
+def test_ping():
+    startNetwork()
+
+    # Start the switches and specify a controller
+    s1 = net.getNodeByName('s1')
+    s2 = net.getNodeByName('s2')
+
+    # Start each controller
+    c1 = net.getNodeByName('c1')
+    c2 = net.getNodeByName('c2')
+    for controller in net.controllers:
+        controller.start()
+    s1.start([c1])
+    s2.start([c2])
+
+    # After switch registered, set protocol to OpenFlow 1.5
+    s1.cmd('ovs-vsctl set bridge s1 protocols=OpenFlow15')
+    s2.cmd('ovs-vsctl set bridge s2 protocols=OpenFlow15')
+
+    # Send non blocking commands to each host
+    h1 = net.getNodeByName('h1')
+    h2 = net.getNodeByName('h2')
+
+    h1.setIP('10.0.0.1', prefixLen=24)
+    h2.setIP('50.0.0.1', prefixLen=24)
+
+    time.sleep(10)
+
+    # REST API to configure AS1 controller
+    c1.addMapping("10.0.0.1", "40.0.0.0/24")
+    c1.addMapping("50.0.0.1", "80.0.0.0/16")
+
+    # REST API to configure AS2 controller
+    c2.addMapping("10.0.0.1", "40.0.0.0/24")
+    c2.addMapping("50.0.0.1", "80.0.0.0/16")
+
+    # End-to-end communication setup as below
+    h1.cmd('route add -net 50.0.0.0 netmask 255.255.255.0 dev h1-eth0')
+    h2.cmd('route add -net 10.0.0.0 netmask 255.255.255.0 dev h2-eth0')
+
+    time.sleep(3)
+
+    # Query flow rules on each switch and write to log file
+    s1.cmd('ovs-ofctl dump-flows s1 -O OpenFlow15 > ' + LOG_PATH + ' s1.log')
+    s2.cmd('ovs-ofctl dump-flows s2 -O OpenFlow15 > ' + LOG_PATH + ' s2.log')
+
+    info("** Testing network connectivity\n")
+    # packet_loss = net.ping(net.hosts)
+    result = h1.cmd('ping -i 1 -c 10 ' + str(h2.IP()))
+    sent, received = net._parsePing(result)
+    info('Sent:' + str(sent) + ' Received:' + str(received) + '\n')
+
+    stopNetwork()
+
+    assert sent - received == 0
+
+
+if __name__ == '__main__':
+    setLogLevel('info')
+    startNetwork()
+    CLI(net)
+    stopNetwork()

--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPInstance.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPInstance.java
@@ -80,6 +80,10 @@ public class DHCPInstance {
 	public Set<VlanVid> getVlanMembers() { return vlanMembers; }
 	public Set<MacAddress> getClientMembers() { return clientMembers; }
 
+	public void addNptMember(NodePortTuple npt) {
+		this.nptMembers.add(npt);
+	}
+
 	public DHCPInstanceBuilder getBuilder() {return builder;}
 
 	private DHCPInstance(DHCPInstanceBuilder builder) {

--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPServer.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPServer.java
@@ -82,7 +82,7 @@ public class DHCPServer implements IOFMessageListener, IFloodlightModule, IDHCPS
     protected IRestApiService restApiService;
 
     private static Map<String, DHCPInstance> dhcpInstanceMap;
-    private static volatile boolean enableDHCPService = false;
+    private static volatile boolean enableDHCPService = true;
 
 
     @Override

--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPServer.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPServer.java
@@ -82,7 +82,7 @@ public class DHCPServer implements IOFMessageListener, IFloodlightModule, IDHCPS
     protected IRestApiService restApiService;
 
     private static Map<String, DHCPInstance> dhcpInstanceMap;
-    private static volatile boolean enableDHCPService = true;
+    private static volatile boolean enableDHCPService = false;
 
 
     @Override

--- a/src/main/java/net/floodlightcontroller/dhcpserver/web/ConfigResource.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/web/ConfigResource.java
@@ -1,0 +1,47 @@
+package net.floodlightcontroller.dhcpserver.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import net.floodlightcontroller.dhcpserver.IDHCPService;
+import org.restlet.resource.Get;
+import org.restlet.resource.Post;
+import org.restlet.resource.Put;
+import org.restlet.resource.ServerResource;
+
+import java.io.IOException;
+
+/**
+ * @author Geddings Barrineau, geddings.barrineau@bigswitch.com on 2/24/18.
+ */
+public class ConfigResource extends ServerResource {
+
+    @Get
+    public Object getConfig() {
+        IDHCPService dhcpService = (IDHCPService) getContext()
+                .getAttributes().get(IDHCPService.class.getCanonicalName());
+
+        return ImmutableMap.of("enabled", dhcpService.isDHCPEnabled());
+    }
+
+    @Put
+    @Post
+    public Object configure(String json) throws IOException {
+        IDHCPService dhcpService = (IDHCPService) getContext()
+                .getAttributes().get(IDHCPService.class.getCanonicalName());
+
+        if (json == null) {
+            setStatus(org.restlet.data.Status.CLIENT_ERROR_BAD_REQUEST, "One or more required fields missing.");
+            return null;
+        }
+
+        JsonNode jsonNode = new ObjectMapper().readTree(json);
+        JsonNode enableNode = jsonNode.get("enable");
+        if (enableNode != null) {
+            if (enableNode.asBoolean()) dhcpService.enableDHCP();
+            else dhcpService.disableDHCP();
+        }
+
+        return getConfig();
+    }
+}

--- a/src/main/java/net/floodlightcontroller/dhcpserver/web/DHCPServerWebRoutable.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/web/DHCPServerWebRoutable.java
@@ -11,6 +11,7 @@ public class DHCPServerWebRoutable implements RestletRoutable {
     @Override
     public Router getRestlet(Context context) {
         Router router = new Router(context);
+        router.attach("/config", ConfigResource.class);
         router.attach("/instance", InstancesResource.class);
         router.attach("/instance/{instance-name}", InstanceResource.class);
         return router;

--- a/src/main/java/net/floodlightcontroller/dhcpserver/web/InstanceResource.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/web/InstanceResource.java
@@ -36,7 +36,6 @@ public class InstanceResource extends ServerResource {
 
     @Put
     @Post
-    // This would also overwrite/update an existing dhcp instance
     public Object updateInstance(String json) throws IOException {
         IDHCPService dhcpService = (IDHCPService) getContext().getAttributes()
                 .get(IDHCPService.class.getCanonicalName());
@@ -49,7 +48,7 @@ public class InstanceResource extends ServerResource {
         }
 
         JsonNode jsonNode = new ObjectMapper().readTree(json);
-        JsonNode switchportsNode = jsonNode.get("switchport");
+        JsonNode switchportsNode = jsonNode.get("switchports");
         if (switchportsNode != null) {
             for (JsonNode swpt : switchportsNode) {
                 JsonNode dpidNode = swpt.get("dpid");


### PR DESCRIPTION
I added a vagrantfile that should automatically setup a mininet environment to test the DHCP service. I also added a DHCP test in `example/mininet/dhcp.py`. The example assumes that the controller is running locally (e.g. in IntelliJ).

~~The whole thing is still pretty rough right now.~~ It's good to go now.